### PR TITLE
Add config-based enable/disable support for integrations

### DIFF
--- a/core.h
+++ b/core.h
@@ -3,12 +3,13 @@
 #include <QObject>
 #include <QVariantMap>
 #include <QMqttSubscription>
-
+#include <KSharedConfig>
 class QMqttClient;
 
 struct IntegrationFactory {
     QString name;
     std::function<void()> factory;
+    bool onByDefault = true;  // ny flagg for default enabled
 };
 
 class HaControl : public QObject {
@@ -19,20 +20,19 @@ public:
 
     static QMqttClient *mqttClient() { return s_self->m_client; }
 
-    static bool registerIntegrationFactory(const QString &name, std::function<void()> plugin);
-
+    static bool registerIntegrationFactory(const QString &name, std::function<void()> plugin, bool onByDefault = true);
+    
 private:
     void doConnect();
-
+    void loadIntegrations(KSharedConfigPtr config);
     static QList<IntegrationFactory> s_integrations;
     static HaControl *s_self;
     QMqttClient *m_client;
 };
 
 // Macro for integrasjoner
-#define REGISTER_INTEGRATION(name) \
-static bool dummy##name = HaControl::registerIntegrationFactory(#name, [](){ name(); });
- 
+#define REGISTER_INTEGRATION(nameStr, func, onByDefault) \
+static bool dummy##func = HaControl::registerIntegrationFactory(nameStr, [](){ func(); }, onByDefault);
 /**
  * @brief The Entity class is a base class for types (binary sensor, sensor, etc)
  */

--- a/integrations/accentcolour.cpp
+++ b/integrations/accentcolour.cpp
@@ -40,6 +40,6 @@ void setupAccentColour()
     new AccentColourWatcher(qApp);
 }
 
-REGISTER_INTEGRATION(setupAccentColour)
+REGISTER_INTEGRATION("AccentColour",setupAccentColour,true)
 
 #include "accentcolour.moc"

--- a/integrations/active.cpp
+++ b/integrations/active.cpp
@@ -25,4 +25,4 @@ void setupActiveSensor()
     sensor->setState(true);
 }
 
-REGISTER_INTEGRATION(setupActiveSensor)
+REGISTER_INTEGRATION("Active", setupActiveSensor, true)

--- a/integrations/activewindow.cpp
+++ b/integrations/activewindow.cpp
@@ -148,10 +148,10 @@ void ActiveWindowWatcher::UpdateAttributes(const QVariantMap &attributes)
 
 
 
-void ActiveWindow()
+void setupActiveWindow()
 {
     new ActiveWindowWatcher(qApp);
 }
 
-REGISTER_INTEGRATION(ActiveWindow)
+REGISTER_INTEGRATION("ActiveWindow",setupActiveWindow,true)
 #include "activewindow.moc"

--- a/integrations/audio.cpp
+++ b/integrations/audio.cpp
@@ -123,10 +123,10 @@ qint64 Audio::percentToPa(int percent) const
     return (qint64)(PulseAudioQt::normalVolume() * (percent / 100.0));
 }
 
-void Volume()
+void setupAudio()
 {
     new Audio(qApp);
 }
 
-REGISTER_INTEGRATION(Volume)
+REGISTER_INTEGRATION("Audio",setupAudio,true)
 #include "audio.moc"

--- a/integrations/camera.cpp
+++ b/integrations/camera.cpp
@@ -186,5 +186,5 @@ void setupCamera()
     new CameraWatcher(qApp);
 }
 
-REGISTER_INTEGRATION(setupCamera)
+REGISTER_INTEGRATION("CameraWatcher",setupCamera,true)
 #include "camera.moc"

--- a/integrations/dndstate.cpp
+++ b/integrations/dndstate.cpp
@@ -17,4 +17,4 @@ void setupDndSensor()
     // copy switch from nightmode
 }
 
-REGISTER_INTEGRATION(setupDndSensor)
+REGISTER_INTEGRATION("DnD",setupDndSensor,true)

--- a/integrations/lockedstate.cpp
+++ b/integrations/lockedstate.cpp
@@ -75,5 +75,5 @@ void registerLockedState()
     new LockedState(qApp);
 }
 
-REGISTER_INTEGRATION(registerLockedState)
+REGISTER_INTEGRATION("LocedState",registerLockedState,true)
 #include "lockedstate.moc"

--- a/integrations/nightmode.cpp
+++ b/integrations/nightmode.cpp
@@ -63,6 +63,6 @@ void setupNightmode()
     new NightMode(qApp);
 }
 
-REGISTER_INTEGRATION(setupNightmode)
+REGISTER_INTEGRATION("Nightmode",setupNightmode,true)
 
 #include "nightmode.moc"

--- a/integrations/notifications.cpp
+++ b/integrations/notifications.cpp
@@ -43,5 +43,5 @@ void setupNotifications()
     new Notifications(qApp);
 }
 
-REGISTER_INTEGRATION(setupNotifications)
+REGISTER_INTEGRATION("Notifications",setupNotifications,true)
 #include "notifications.moc"

--- a/integrations/scripts.cpp
+++ b/integrations/scripts.cpp
@@ -36,4 +36,4 @@ void registerScripts()
         });
     }
 }
-REGISTER_INTEGRATION(registerScripts)
+REGISTER_INTEGRATION("Scripts",registerScripts,true)

--- a/integrations/shortcuts.cpp
+++ b/integrations/shortcuts.cpp
@@ -26,4 +26,4 @@ void registerShortcuts()
     }
 }
 
-REGISTER_INTEGRATION(registerShortcuts)
+REGISTER_INTEGRATION("Shortcuts",registerShortcuts,true)

--- a/integrations/suspend.cpp
+++ b/integrations/suspend.cpp
@@ -45,4 +45,4 @@ void setupSuspend()
     }
 }
 
-REGISTER_INTEGRATION(setupSuspend)
+REGISTER_INTEGRATION("PowerController",setupSuspend,true)


### PR DESCRIPTION
This PR adds support for enabling or disabling individual integrations via the [Integrations] section in the config.

- Integrations now register themselves with REGISTER_INTEGRATION(setupFunction) (e.g., setupActiveWindow).
- The code checks [Integrations] in the config:
  - If the group does not exist, all integrations are started by default.
  - If the group exists and contains entries, only integrations explicitly enabled (true) are started; others are skipped.

This is how the config file would look:
`[Integrations]
ActiveWindow=true
Volume=false
`

Question / proposal:
I have not renamed the original REGISTER_INTEGRATION() calls in the original integrations. Should I handle renaming them consistently in this PR, or would you prefer to do it yourself?

All changes have been tested and work as expected.