### PR TITLE
Fixed small compile problem

### DIFF
--- a/integrations/accentcolour.cpp
+++ b/integrations/accentcolour.cpp
@@ -46,12 +46,3 @@ void setupAccentColour()
 REGISTER_INTEGRATION("AccentColour",setupAccentColour,true)
 
 #include "accentcolour.moc"
-#include "core.h"
-#include <QCoreApplication>
-
-#include <KSharedConfig>
-#include <KConfigGroup>
-#include <KConfigWatcher>
-
-
-class AccentColourWatcher: public QObject {


### PR DESCRIPTION
Last commit would not compile, found this code at the bottom of "accentcolour.cpp", since it looks like a copy of the top of the file i just deleted it and compiling works again

```
#include "core.h"
#include <QCoreApplication>

#include <KSharedConfig>
#include <KConfigGroup>
#include <KConfigWatcher>


class AccentColourWatcher: public QObject {

```