### PR TITLE
Fixing first-time registered entities showing up as unavailable in HA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,6 @@ set(SOURCES
     dbusproperty.cpp
     dbusproperty.h
     entities/entity.cpp
-    entities/battery.cpp
     entities/binarysensor.cpp
     entities/button.cpp
     entities/number.cpp


### PR DESCRIPTION
This is a quick and dirty fix in the Entity::sendRegistration method to ensure that entities are available in Home Assistant immediately after first registration. I’m not fully confident this is the “correct” way, but it’s tested and working.

Until I learn more about MQTT/HA communication, this seems like the best solution to this problem.

More info about the problem, including screenshots, can be found here:
https://github.com/TheOddPirate/kiot/issues/1

Note:
I also took some time to better understand rebasing from upstream. I fixed my master branch history locally, so it should now be clean?