### PR TITLE
Fix offline state on shutdown by ensuring ConnectedNode is destroyed before MQTT disconnect

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -77,7 +77,9 @@ HaControl::HaControl() {
 
 HaControl::~HaControl()
 {
-    delete ConnectedNode::node();
+    if (auto node = ConnectedNode::node()) {
+        delete node;
+    }
     // This is probably not needed, but was added to make sure the client disconnects
     m_client->disconnectFromHost();
 }


### PR DESCRIPTION
This PR introduces a static instance pointer in `ConnectedNode` to make the active node globally accessible, similar to how `HaControl` exposes the MQTT client.

The pointer is explicitly deleted in the `HaControl` destructor to ensure the device publishes its offline state to Home Assistant before the MQTT client disconnects.

This resolves the issue created when making a safe shutdown handler,
where the device sometimes remained online in Home Assistant for a while after a clean shutdown.

This PR also includes the previously fixed CMakeLists changes from the related PR.