### PR TITLE
Drop setHaConfig

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -131,19 +131,17 @@ ConnectedNode::ConnectedNode(QObject *parent):
     setId("connected");
     setName("Connected");
     setHaType("binary_sensor");
-    setHaConfig({
-        {"state_topic", baseTopic()},
-        {"payload_on", "on"},
-        {"payload_off", "off"},
-        {"device_class", "power"},
-        {"device", QVariantMap({
+    setDiscoveryConfig("state_topic", baseTopic());
+    setDiscoveryConfig("payload_on", "on");
+    setDiscoveryConfig("payload_off", "off");
+    setDiscoveryConfig("device_class", "power");
+    setDiscoveryConfig("device", QVariantMap({
                        {"name", hostname() },
                        {"identifiers", "linux_ha_bridge_" + hostname() },
                        {"sw_version", "0.1"},
                        {"manufacturer", "Linux HA Bridge"},
                        {"model", "Linux"}
-                   })}
-    });
+                   }));
 
     auto c = HaControl::mqttClient();
     c->setWillTopic(baseTopic());
@@ -172,4 +170,3 @@ ConnectedNode::~ConnectedNode()
 
 
 #include "core.moc"
-

--- a/entities/binarysensor.cpp
+++ b/entities/binarysensor.cpp
@@ -12,11 +12,9 @@ BinarySensor::BinarySensor(QObject *parent)
 void BinarySensor::init()
 {
     setHaType("binary_sensor");
-    setHaConfig({
-        {"state_topic", baseTopic()},
-        {"payload_on", "true"},
-        {"payload_off", "false"}
-    });
+    setDiscoveryConfig("state_topic", baseTopic());
+    setDiscoveryConfig("payload_on", "true");
+    setDiscoveryConfig("payload_off", "false");
     sendRegistration();
     publish();
 }

--- a/entities/button.cpp
+++ b/entities/button.cpp
@@ -13,9 +13,7 @@ Button::Button(QObject *parent)
 void Button::init()
 {
     setHaType("button");
-    setHaConfig({
-        {"command_topic", baseTopic()}
-    });
+    setDiscoveryConfig("command_topic", baseTopic());
     sendRegistration();
 
     auto subscription = HaControl::mqttClient()->subscribe(baseTopic());

--- a/entities/entity.cpp
+++ b/entities/entity.cpp
@@ -23,11 +23,6 @@ QString Entity::baseTopic() const
     return hostname() + "/" + id();
 }
 
-void Entity::setHaConfig(const QVariantMap &newHaConfig)
-{
-    m_haConfig = newHaConfig;
-}
-
 QString Entity::haType() const
 {
     return m_haType;

--- a/entities/entity.h
+++ b/entities/entity.h
@@ -32,7 +32,6 @@ protected:
      * Called on MQTT connect, it may be called more than once
      */
     virtual void init();
-    void setHaConfig(const QVariantMap &newHaConfig);
     void sendRegistration();
     void setHaType(const QString &newHaType);
     QString haType() const;

--- a/entities/event.cpp
+++ b/entities/event.cpp
@@ -12,12 +12,10 @@ Event::Event(QObject *parent)
 void Event::init()
 {
     setHaType("device_automation");
-    setHaConfig({
-        {"automation_type", "trigger"},
-        {"topic", baseTopic()},
-        {"type", {"button_short_press"}},
-        {"subtype", name()}
-    });
+    setDiscoveryConfig("automation_type", "trigger");
+    setDiscoveryConfig("topic", baseTopic());
+    setDiscoveryConfig("type", QStringLiteral("button_short_press"));
+    setDiscoveryConfig("subtype", name());
     sendRegistration();
 }
 

--- a/entities/number.cpp
+++ b/entities/number.cpp
@@ -20,13 +20,12 @@ void Number::setRange(int min, int max, int step, const QString &unit)
 
 void Number::init()
 {
-    setHaConfig({ {"state_topic", baseTopic()},
-            {"command_topic", baseTopic() + "/set"},
-            {"min", QString::number(m_min)},
-            {"max", QString::number(m_max)},
-            {"step", QString::number(m_step)},
-            {"unit_of_measurement", m_unit}
-    });
+    setDiscoveryConfig("state_topic", baseTopic());
+    setDiscoveryConfig("command_topic", baseTopic() + "/set");
+    setDiscoveryConfig("min", QString::number(m_min));
+    setDiscoveryConfig("max", QString::number(m_max));
+    setDiscoveryConfig("step", QString::number(m_step));
+    setDiscoveryConfig("unit_of_measurement", m_unit);
  
 
     sendRegistration();

--- a/entities/select.cpp
+++ b/entities/select.cpp
@@ -19,11 +19,9 @@ void Select::setOptions(const QStringList &opts)
     m_options = opts;
 
     // Hvis HA er registrert, må config oppdateres
-    setHaConfig({
-        {"state_topic", baseTopic()},
-        {"command_topic", baseTopic() + "/set"},
-        {"options", QJsonArray::fromStringList(m_options)}
-    });
+    setDiscoveryConfig("state_topic", baseTopic());
+    setDiscoveryConfig("command_topic", baseTopic() + "/set");
+    setDiscoveryConfig("options", QJsonArray::fromStringList(m_options));
     sendRegistration();
 }
 
@@ -45,11 +43,9 @@ QStringList Select::getOptions() const
 void Select::init()
 {
     // Startkonfig for HA
-    setHaConfig({
-        {"state_topic", baseTopic()},
-        {"command_topic", baseTopic() + "/set"},
-        {"options", QJsonArray::fromStringList(m_options)}
-    });
+    setDiscoveryConfig("state_topic", baseTopic());
+    setDiscoveryConfig("command_topic", baseTopic() + "/set");
+    setDiscoveryConfig("options", QJsonArray::fromStringList(m_options));
 
     // Fortell HA at entiteten finnes
     sendRegistration();

--- a/entities/sensor.cpp
+++ b/entities/sensor.cpp
@@ -16,10 +16,8 @@ void Sensor::init()
     setHaType("sensor");
 
     // Standard state topic
-    setHaConfig({
-        {"state_topic", baseTopic()},
-        {"json_attributes_topic", baseTopic() + "/attributes"} // ny topic for attributes
-    });
+    setDiscoveryConfig("state_topic", baseTopic());
+    setDiscoveryConfig("json_attributes_topic", baseTopic() + "/attributes"); // ny topic for attributes
 
     sendRegistration();
     publishState();

--- a/entities/switch.cpp
+++ b/entities/switch.cpp
@@ -16,13 +16,11 @@ Switch::Switch(QObject *parent)
 
 void Switch::init()
 {
-    setHaConfig({
-        {"state_topic", baseTopic()},
-        {"command_topic", baseTopic() + "/set"},
-        {"payload_on", "true"},
-        {"payload_off", "false"},
-         {"json_attributes_topic", baseTopic() + "/attributes"} 
-    });
+    setDiscoveryConfig("state_topic", baseTopic());
+    setDiscoveryConfig("command_topic", baseTopic() + "/set");
+    setDiscoveryConfig("payload_on", "true");
+    setDiscoveryConfig("payload_off", "false");
+    setDiscoveryConfig("json_attributes_topic", baseTopic() + "/attributes"); 
 
     sendRegistration();
     setState(m_state);
@@ -64,4 +62,3 @@ void Switch::publishAttributes()
     QJsonDocument doc(obj);
     HaControl::mqttClient()->publish(baseTopic() + "/attributes", doc.toJson(QJsonDocument::Compact), 0, true);
 }
-

--- a/entities/textbox.cpp
+++ b/entities/textbox.cpp
@@ -17,11 +17,9 @@ Textbox::Textbox(QObject *parent)
 
 void Textbox::init()
 {
-    setHaConfig({
-        {"state_topic", baseTopic()},
-        {"command_topic", baseTopic() + "/set"},
-        {"json_attributes_topic", baseTopic() + "/attributes"}
-    });
+    setDiscoveryConfig("state_topic", baseTopic());
+    setDiscoveryConfig("command_topic", baseTopic() + "/set");
+    setDiscoveryConfig("json_attributes_topic", baseTopic() + "/attributes");
 
     sendRegistration();
     setState(m_text);


### PR DESCRIPTION
We confusingly had one method to set all attributes, one to override one in an existing setup.

This made it order dependent and quite messy.