### PR TITLE
Retain availability

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -21,6 +21,7 @@ class ConnectedNode: public Entity
 public:
     ConnectedNode(QObject *parent);
     ~ConnectedNode();
+    void init() override;
 };
 
 HaControl::HaControl() {
@@ -148,20 +149,18 @@ ConnectedNode::ConnectedNode(QObject *parent):
     c->setWillTopic(baseTopic());
     c->setWillMessage("off");
     c->setWillRetain(true);
-
-    connect(HaControl::mqttClient(), &QMqttClient::connected, this, [this]() {
-        sendRegistration();
-         HaControl::mqttClient()->publish(baseTopic(), "on", 0, false);
-   
-    });
 }
 
 ConnectedNode::~ConnectedNode()
 {
-    // TODO find a good way to let this entity publish before shutdown is done and not cause a coredump
-    HaControl::mqttClient()->publish(baseTopic(), "off", 0, false);
+    HaControl::mqttClient()->publish(baseTopic(), "off", 0, true);
 }
 
+void ConnectedNode::init()
+{
+    sendRegistration();
+    HaControl::mqttClient()->publish(baseTopic(), "on", 0, true);
+}
 
 
 


### PR DESCRIPTION
Otherwise when sensors are first initialised to Home Assistant, HA (correctly) waits for the next time the next availability state changes.

It works the second time kiot is launched, because in that case HA already knows the entity has registered the availability topic so is waiting for it.

If the state is maintained, HA uses the retained value. The will message will take care of cleanup.