### PR TITLE
Clang format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,10 @@ find_package(KF6 "1.7.0" REQUIRED COMPONENTS
 )
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
+include(KDEClangFormat)
+file(GLOB_RECURSE ALL_CLANG_FORMAT_SOURCE_FILES *.cpp *.h *.hpp *.c)
+kde_clang_format(${ALL_CLANG_FORMAT_SOURCE_FILES})
+
 set(SOURCES
     main.cpp
     core.cpp

--- a/core.h
+++ b/core.h
@@ -38,11 +38,10 @@ private:
     ConnectedNode *m_connectedNode;
 };
 
-// Macro for integrasjoner
+// clang-format off
+
+// Macro for integrations
 #define REGISTER_INTEGRATION(nameStr, func, onByDefault) \
 static bool dummy##func = HaControl::registerIntegrationFactory(nameStr, [](){ func(); }, onByDefault);
-/**
- * @brief The Entity class is a base class for types (binary sensor, sensor, etc)
- */
 
-
+// clang-format on


### PR DESCRIPTION
Set things up for clang format.

Next step is running ' make clang-format' in the build directory, but I'll do that after other patches land.