### PR TITLE
Fix camera integration crash on repeated Bluetooth connect and disconnect

### DIFF
--- a/integrations/camera.cpp
+++ b/integrations/camera.cpp
@@ -191,7 +191,7 @@ void CameraWatcher::onVideoDeviceAdded(const QString &devicePath)
 void CameraWatcher::onVideoDeviceRemoved(const QString &devicePath)
 {
     int fd = m_watchFds.take(devicePath);
-    if (fd != -1) {
+    if (fd >= 1) {
         inotify_rm_watch(m_inotifyFd, fd);
     }
     m_deviceOpenCounts.remove(devicePath);


### PR DESCRIPTION
While testing the battery integration by repeatedly connecting and disconnecting a Bluetooth headset, the camera integration would consistently crash with a core dump.

The terminal always reported the following assertion failure:

```
ASSERT: "openCount >= 0" in file integrations/camera.cpp, line 159  
zsh: IOT instruction (core dumped) ./bin/kiot

```

The root cause is that the original implementation maintains a single global openCount across all /dev/video* devices. When devices are added, removed, or re-registered at runtime, this counter can become desynchronized from the actual device state, leading to negative values and triggering the assertion.

What this PR changes
- Replaces the global openCount with a per-device open counter using QHash<QString, int>.
- Tracks open and close events per video device instead of globally.
- Properly handles IN_DELETE_SELF by clearing the affected device state.
- Ensures the camera sensor state is derived from the total sum of all device open counts.
- Keeps the original hysteresis behavior for short probe opens.
- Prevents the negative counter condition that caused the crash.

Testing
- The original crash was reliably reproducible by connecting and disconnecting a Bluetooth headset.
With this patch applied, the crash no longer occurs.
- Verified that with this patch applied, the camera integration no longer crashes and behaves as before.
- Confirmed correct state transitions for camera active and inactive.

This change makes the camera integration resilient to device churn and dynamic /dev/video* lifecycles without altering the external behavior.